### PR TITLE
feat: Add button for warpcast intent to share /view/:id frame

### DIFF
--- a/frames/api/index.tsx
+++ b/frames/api/index.tsx
@@ -157,10 +157,10 @@ app.frame("/poster/3/:ipfsHash/:id", async (c) => {
     return c.res({
       image: <FrameWithText title="Done!" />,
       intents: [
-        <Button.Link href={`https://warpcast.com/~/compose?text=https://only-frames.vercel.app/api/view/${id}`}>Share on Warpcast</Button.Link>,
-        <Button action={`/view/${id}`}>View Content</Button>,
+        <Button.Link href={`https://warpcast.com/~/compose?text=https://only-frames.vercel.app/api/view/${id}`}>Share</Button.Link>,
+        <Button action={`/view/${id}`}>View Now</Button>,
         <Button.Link href="https://only-frames.vercel.app">
-          View all paywalled content
+          View All
         </Button.Link>,
       ],
     });

--- a/frames/api/index.tsx
+++ b/frames/api/index.tsx
@@ -157,6 +157,7 @@ app.frame("/poster/3/:ipfsHash/:id", async (c) => {
     return c.res({
       image: <FrameWithText title="Done!" />,
       intents: [
+        <Button.Link href={`https://warpcast.com/~/compose?text=https://only-frames.vercel.app/api/view/${id}`}>Share on Warpcast</Button.Link>,
         <Button action={`/view/${id}`}>View Content</Button>,
         <Button.Link href="https://only-frames.vercel.app">
           View all paywalled content


### PR DESCRIPTION
Kind of overflows, any thoughts on this or okay to leave as is?
<img width="548" alt="image" src="https://github.com/marcuspang/only-frames/assets/56021409/82eefee3-93ca-4a42-be0a-0cf725a89c37">
